### PR TITLE
Fix/rnaseq tracks

### DIFF
--- a/conf/ini-files/Aedes_aegypti.ini
+++ b/conf/ini-files/Aedes_aegypti.ini
@@ -812,7 +812,7 @@ display        = off
 source_name    = Female adult antennae, HU2 isolate - F2 hybrids (McBride 2014)
 caption        = McBride (2014)
 description    = Pooled antennae from 2-3 week post-eclosion adult females with human feeding preference (McBride et al. 2014) <a href="/data/aedes-aegypti-female-antennae-gp1-isolate-f2-hybrids">More details</a>
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/aedes_aegypti/SRP035216_HU21_AaegL2.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/aedes_aegypti/SRP035216_HU2_AaegL2.bw
 source_type    = bigWig
 display        = off
 
@@ -884,7 +884,7 @@ display        = off
 source_name    = 48 hr post bloodmeal female antennae Fe_An_BF (Matthews 2014)
 caption        = Matthews (2014)
 description    = Aedes aegypti Liverpool strain antennae from blood-fed females (Matthews unpublished 2014)
-source_url     = NULL
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/aedes_aegypti/SRP037535_FeAnBF_AaegL2.bw
 source_type    = bigWig
 display        = off
 

--- a/conf/ini-files/Anopheles_merus.ini
+++ b/conf/ini-files/Anopheles_merus.ini
@@ -27,7 +27,7 @@ SRP020545_AGC_merus_RNAseq = rnaseq_align
 source_name    = AGC An. merus RNAseq
 caption        = AGC (2013)
 description    = </br>SRP020545 <a href=http://www.ncbi.nlm.nih.gov/sra/SRX200222>SRX200222</a><a href=http://www.ncbi.nlm.nih.gov/sra/SRX200223>SRX200223</a></br> Sequencing of a generic RNA sample to aid gene prediction. <a href="http://www.ncbi.nlm.nih.gov/pubmed/25554792">Neafsey et al 2015</a>
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_merus/SRP020545_merged_AmerM1.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_merus/SRP020545_merged_AmerM2.bw
 source_type    = bigWig
 display        = off
 

--- a/conf/ini-files/Anopheles_stephensi.ini
+++ b/conf/ini-files/Anopheles_stephensi.ini
@@ -39,18 +39,6 @@ PRJNA238805_MSQ43_1 = rnaseq_align
 PRJNA238805_MSQ43_2 = rnaseq_align
 PRJNA238805_MSQ43_3 = rnaseq_align
 PRJNA238805_MSQ43_4 = rnaseq_align
-# Community samples
-SRP013839_0_1_hr_embryos = rnaseq_align
-SRP013839_24_hr_post_blood_meal_carcass_female = rnaseq_align
-SRP013839_24_hr_post_blood_meal_ovaries_female = rnaseq_align
-SRP013839_2_4_hr_embryos = rnaseq_align
-SRP013839_4_8_hr_embryos = rnaseq_align
-SRP013839_8_12_hr_embryos = rnaseq_align
-SRP013839_adult_female = rnaseq_align
-SRP013839_adult_male = rnaseq_align
-SRP013839_larvae = rnaseq_align
-SRP013839_post_emergence_ovaries = rnaseq_align
-SRP013839_pupae = rnaseq_align
 
 [SRP020546_AGC_stephensi_RNAseq]
 source_name    = AGC An. stephensi RNAseq
@@ -89,94 +77,6 @@ source_name    = MSQ43 cell line replicate 4 (AVCL 2014)
 caption        = AVCL (2014)
 description    = NIAID Arthropod Vector-derived cell line transcriptome, MSQ43 line, replicate 4
 source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/PRJNA238805_MRA858_4_AsinS1.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_0_1_hr_embryos]
-source_name    = 0-1 hr embryos
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi 0-1 hr embryos (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155660_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_24_hr_post_blood_meal_carcass_female]
-source_name    = 24 hr post blood meal carcass
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi female 24 hr post blood mean carcass, ovaries removed  (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155659_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_24_hr_post_blood_meal_ovaries_female]
-source_name    = 24 hr post blood meal ovaries
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi 24 hours post blood meal ovaries (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155654_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_2_4_hr_embryos]
-source_name    = 2-4 hr embryos
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi 2-4 hr embryos (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155661_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_4_8_hr_embryos]
-source_name    = 4-8 hr embryos
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi 4-8 hr embryos (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155405_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_8_12_hr_embryos]
-source_name    = 8-12 hr embryos
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi 8-12 hr embryos (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155649_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_adult_female]
-source_name    = Adult female
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi adult female (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155652_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_adult_male]
-source_name    = Adult male
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi adult male (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155653_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_larvae]
-source_name    = Larvae
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi larvae (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155650_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_post_emergence_ovaries]
-source_name    = Ovaries post emergence
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi ovaries post emergence (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155655_AsteI2.bw
-source_type    = bigWig
-display        = off
-
-[SRP013839_pupae]
-source_name    = Pupae
-caption        = Tu (2012)
-description    = SRP013839 Transcriptomics sequencing of Anopheles stephensi pupae (Tu unpublished 2012).
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155651_AsteI2.bw
 source_type    = bigWig
 display        = off
 

--- a/conf/ini-files/Anopheles_stephensi.ini
+++ b/conf/ini-files/Anopheles_stephensi.ini
@@ -52,7 +52,7 @@ display        = off
 source_name    = MSQ43 cell line replicate 1 (AVCL 2014)
 caption        = AVCL (2014)
 description    = NIAID Arthropod Vector-derived cell line transcriptome, MSQ43 line, replicate 1
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/PRJNA238805_MRA858_1_AsinS1.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/PRJNA238805_MRA858_1_AsteS1.bw
 source_type    = bigWig
 display        = off
 
@@ -60,7 +60,7 @@ display        = off
 source_name    = MSQ43 cell line replicate 2 (AVCL 2014)
 caption        = AVCL (2014)
 description    = NIAID Arthropod Vector-derived cell line transcriptome, MSQ43 line, replicate 2
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/PRJNA238805_MRA858_2_AsinS1.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/PRJNA238805_MRA858_2_AsteS1.bw
 source_type    = bigWig
 display        = off
 
@@ -68,7 +68,7 @@ display        = off
 source_name    = MSQ43 cell line replicate 3 (AVCL 2014)
 caption        = AVCL (2014)
 description    = NIAID Arthropod Vector-derived cell line transcriptome, MSQ43 line, replicate 3
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/PRJNA238805_MRA858_3_AsinS1.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/PRJNA238805_MRA858_3_AsteS1.bw
 source_type    = bigWig
 display        = off
 
@@ -76,7 +76,7 @@ display        = off
 source_name    = MSQ43 cell line replicate 4 (AVCL 2014)
 caption        = AVCL (2014)
 description    = NIAID Arthropod Vector-derived cell line transcriptome, MSQ43 line, replicate 4
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/PRJNA238805_MRA858_4_AsinS1.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/PRJNA238805_MRA858_4_AsteS1.bw
 source_type    = bigWig
 display        = off
 

--- a/conf/ini-files/Glossina_palpalis.ini
+++ b/conf/ini-files/Glossina_palpalis.ini
@@ -38,12 +38,12 @@ DATABASE_USERDATA  = glossina_palpalis_userdata
 #################
 
 [ENSEMBL_INTERNAL_BIGWIG_SOURCES]
-SRP017756_GGC_pallidipes_RNAseq = rnaseq_align
+SRP015954_GGC_palpalis_RNAseq = rnaseq_align
 
-[SRP017756_GGC_pallidipes_RNAseq]
-source_name    = GGC G. pallidipes RNAseq
-caption        = GGC (2014)
-description    = </br>SRP017756 Sequencing of a generic RNA sample to aid gene prediction
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/glossina_pallidipes/SRP017756_GGC_pallidipes_RNAseq.bw
+[SRP015954_GGC_palpalis_RNAseq]
+source_name    = GGC G. palpalis RNAseq
+caption        = GGC (2012)
+description    = </br>SRP015954 Transcriptome Analysis
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/glossina_palpalis/SRP015954_GGC_palpalis_RNAseq.bw
 source_type    = bigWig
 display        = off

--- a/conf/ini-files/Phlebotomus_papatasi.ini
+++ b/conf/ini-files/Phlebotomus_papatasi.ini
@@ -48,7 +48,7 @@ SGC_Male = rnaseq_align
 source_name    = SGC 24hr blood fed
 caption        = SGC (2014)
 description    = Adult females 24 hrs after a blood meal
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_24h_blood_fed.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_24hr_blood-fed.bw
 source_type    = bigWig
 display        = off
 
@@ -56,7 +56,7 @@ display        = off
 source_name    = SGC 24hr infected
 caption        = SGC (2014)
 description    = Adult females 24 hrs after infection
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_24h_infected.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_24hr_infected.bw
 source_type    = bigWig
 display        = off
 
@@ -64,7 +64,7 @@ display        = off
 source_name    = SGC 6hr blood fed
 caption        = SGC (2014)
 description    = Adult females 6 hrs after a blood meal
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_6h_blood_fed.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_6hr_blood_fed.bw
 source_type    = bigWig
 display        = off
 
@@ -72,7 +72,7 @@ display        = off
 source_name    = SGC 6hr infected
 caption        = SGC (2014)
 description    = Adult females 6 hrs after infection
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_6h_infected.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_6hr_infected.bw
 source_type    = bigWig
 display        = off
 
@@ -80,7 +80,7 @@ display        = off
 source_name    = SGC 96hr blood fed
 caption        = SGC (2014)
 description    = Adult females 96 hrs after a blood meal
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_96h_blood_fed.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_96hr_blood_fed.bw
 source_type    = bigWig
 display        = off
 
@@ -88,7 +88,7 @@ display        = off
 source_name    = SGC 96hr infected
 caption        = SGC (2014)
 description    = Adult females 96 hrs after infection
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_96h_infected.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_96hr_infected.bw
 source_type    = bigWig
 display        = off
 
@@ -96,7 +96,7 @@ display        = off
 source_name    = SGC Female
 caption        = SGC (2014)
 description    = female
-source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_female.bw
+source_url     = ftp://ftp.vectorbase.org/public_data/bigwig/phlebotomus_papatasi/SGC_Female.bw
 source_type    = bigWig
 display        = off
 


### PR DESCRIPTION
The RNAseq tracks defined in the conf/ini-files have some mistakes (typos or wrong files). When they are used in the Genome Browser, they display an empty track (wrong file) or an error (missing file).
I compared the files in the ftp with all the files defined in the ini files: these commit should correct the errors I found.
