### PR TITLE
Erronous track file names for A. stephensi Indian

### DIFF
--- a/conf/ini-files/Anopheles_stephensiI.ini
+++ b/conf/ini-files/Anopheles_stephensiI.ini
@@ -121,7 +121,7 @@ caption     = Tu (2012)
 [SRP013839_SRX155660_AsteI2]
 source_name = 0-1 hr embryos
 description = </br>SRP013839 <a href="http://www.ncbi.nlm.nih.gov/sra/SRX155660">SRX155660</a></br> The Transcriptome of the Asian malaria mosquito Anopheles stephensi. <a href="https://pre.vectorbase.org/data/anopheles-stephensi-0-1-hr-embryos-unpublished">More information</a>.
-source_url  = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155660_AsteI2_0-1_hr_embryos.bw
+source_url  = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155660_AsteI2.bw
 source_type = bigWig
 display     = wiggle
 caption     = Tu (2012)
@@ -129,7 +129,8 @@ caption     = Tu (2012)
 [SRP013839_SRX155661_AsteI2]
 source_name = 2-4 hr embryos
 description = </br>SRP013839 <a href="http://www.ncbi.nlm.nih.gov/sra/SRX155661">SRX155661</a></br> The Transcriptome of the Asian malaria mosquito Anopheles stephensi. <a href="https://pre.vectorbase.org/data/anopheles-stephensi-2-4-hr-embryos-unpublished">More information</a>.
-source_url  = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155661_AsteI2_2-4_hr_embryos.bw
+source_url  = ftp://ftp.vectorbase.org/public_data/bigwig/anopheles_stephensi/SRP013839_SRX155661_AsteI2.bw
 source_type = bigWig
 display     = wiggle
 caption     = Tu (2012)
+


### PR DESCRIPTION
2 RNAseq track urls for A. stephensi India were wrong.
